### PR TITLE
Bip32 Add skip flags and optimize path derivation

### DIFF
--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -19,6 +19,8 @@
 #define BIP32_FLAG_KEY_PRIVATE 0x0
 /** Indicate that we want to derive a public key in @bip32_key_from_parent */
 #define BIP32_FLAG_KEY_PUBLIC  0x1
+/** Indicate that we want to skip hash calculation when deriving a key in @bip32_key_from_parent */
+#define BIP32_FLAG_SKIP_HASH 0x2
 
 /** Version codes for extended keys */
 #define BIP32_VER_MAIN_PUBLIC  0x0488B21E


### PR DESCRIPTION
- BIP32: Flags: Optionally allow to skip the calculation of public keys and hashes
- Optimization: bip32_key_from_parent_path()
   Don't calculate public keys (assuming we're deriving private keys) nor hashes in intermediate nodes.
