### PR TITLE
BIP32: Protect unused flag bits

### DIFF
--- a/src/bip32.c
+++ b/src/bip32.c
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#define BIP32_ALL_DEFINED_FLAGS (BIP32_FLAG_KEY_PRIVATE | BIP32_FLAG_KEY_PUBLIC | BIP32_FLAG_SKIP_HASH)
+
 static const unsigned char SEED[] = {
     'B', 'i', 't', 'c', 'o', 'i', 'n', ' ', 's', 'e', 'e', 'd'
 };
@@ -260,6 +262,9 @@ int bip32_key_serialize(const struct ext_key *key_in, uint32_t flags,
     uint32_t tmp32;
     beint32_t tmp32_be;
 
+    if (flags & ~BIP32_FLAG_KEY_PUBLIC)
+        return WALLY_EINVAL; /* Only this flag makes sense here */
+
     /* Validate our arguments and then the input key */
     if (!key_in ||
         (serialize_private && !key_is_private(key_in)) ||
@@ -397,6 +402,9 @@ int bip32_key_from_parent(const struct ext_key *key_in, uint32_t child_num,
     const bool we_are_private = key_in && key_is_private(key_in);
     const bool derive_private = !(flags & BIP32_FLAG_KEY_PUBLIC);
     const bool hardened = child_is_hardened(child_num);
+
+    if (flags & ~BIP32_ALL_DEFINED_FLAGS)
+        return WALLY_EINVAL; /* These flags are not defined yet */
 
     if (!key_in || !key_out)
         return WALLY_EINVAL;
@@ -537,6 +545,9 @@ int bip32_key_from_parent_path(const struct ext_key *key_in,
     struct ext_key tmp[2];
     size_t i, tmp_idx = 0;
     int ret;
+
+    if (flags & ~BIP32_ALL_DEFINED_FLAGS)
+        return WALLY_EINVAL; /* These flags are not defined yet */
 
     if (!key_in || !child_num_in || !child_num_len || !key_out)
         return WALLY_EINVAL;

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -52,6 +52,7 @@ for f in (
     ('base58_from_bytes', c_int, [c_void_p, c_ulong, c_uint, c_char_p_p]),
     ('base58_get_length', c_int, [c_char_p, c_ulong_p]),
     ('base58_to_bytes', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
+    ('bip32_key_free', c_int, [POINTER(ext_key)]),
     ('bip32_key_from_seed', c_int, [c_void_p, c_ulong, c_uint, POINTER(ext_key)]),
     ('bip32_key_serialize', c_int, [POINTER(ext_key), c_uint, c_void_p, c_ulong]),
     ('bip32_key_unserialize', c_int, [c_void_p, c_uint, POINTER(ext_key)]),


### PR DESCRIPTION
Test for flag bits that are not yet defined to prevent back compat issues with existing users going forward.
