### PR TITLE
BIP38: Protect unused flag bits

### DIFF
--- a/src/bip38.c
+++ b/src/bip38.c
@@ -18,6 +18,17 @@
 #define BIP38_FLAGS_RESERVED (BIP38_FLAG_RESERVED1 | BIP38_FLAG_RESERVED2 | \
                               BIP38_FLAG_RESERVED3 | BIP38_FLAG_RESERVED4)
 
+#define BIP38_ALL_DEFINED_FLAGS (BIP38_KEY_MAINNET |      \
+                                 BIP38_KEY_TESTNET |      \
+                                 BIP38_KEY_COMPRESSED |   \
+                                 BIP38_KEY_EC_MULT |      \
+                                 BIP38_KEY_QUICK_CHECK |  \
+                                 BIP38_KEY_RAW_MODE |     \
+                                 BIP38_KEY_SWAP_ORDER |   \
+                                 BIP38_FLAG_DEFAULT |     \
+                                 BIP38_FLAG_COMPRESSED |  \
+                                 BIP38_FLAG_HAVE_LOT)
+
 #define BIP38_DERVIED_KEY_LEN 64u
 
 #define BIP38_PREFIX   0x01
@@ -123,6 +134,9 @@ int bip38_raw_from_private_key(const unsigned char *bytes_in, size_t len_in,
     struct bip38_layout_t buf;
     int ret = WALLY_EINVAL;
 
+    if (flags & ~BIP38_ALL_DEFINED_FLAGS)
+        goto finish;
+
     if (!bytes_in || len_in != EC_PRIVATE_KEY_LEN ||
         !bytes_out || len != BIP38_SERIALIZED_LEN)
         goto finish;
@@ -173,6 +187,9 @@ int bip38_from_private_key(const unsigned char *bytes_in, size_t len_in,
     struct bip38_layout_t buf;
     int ret;
 
+    if (flags & ~BIP38_ALL_DEFINED_FLAGS)
+        return WALLY_EINVAL;
+    
     if (!output)
         return WALLY_EINVAL;
 
@@ -212,6 +229,9 @@ static int to_private_key(const char *bip38,
     struct derived_t derived;
     struct bip38_layout_t buf;
     int ret = WALLY_EINVAL;
+
+    if (flags & ~BIP38_ALL_DEFINED_FLAGS)
+        goto finish;
 
     if (!(flags & BIP38_KEY_QUICK_CHECK) &&
         (!bytes_out || len != EC_PRIVATE_KEY_LEN))

--- a/src/test/test_bip38.py
+++ b/src/test/test_bip38.py
@@ -69,15 +69,34 @@ class BIP38Tests(unittest.TestCase):
             priv_key, passwd, flags, expected = case
             passwd = utf8(passwd) if type(passwd) is not bytes else passwd
             ret, bip38 = self.from_priv(priv_key, passwd, flags)
-            self.assertEqual(ret, 0)
+            self.assertEqual(ret, WALLY_OK)
             bip38 = bip38.decode('utf-8') if type(bip38) is bytes else bip38
             self.assertEqual(bip38, expected)
 
             ret, new_priv_key = self.to_priv(bip38, passwd, flags)
-            self.assertEqual(ret, 0)
+            self.assertEqual(ret, WALLY_OK)
             self.assertEqual(h(new_priv_key).upper(), utf8(priv_key))
             ret, new_priv_key = self.to_priv(bip38, '', flags + K_CHECK)
-            self.assertEqual(ret, 0)
+            self.assertEqual(ret, WALLY_OK)
+
+
+    def test_bip38_invalid(self):
+        priv_key = 'CBF4B9F70470856BB4F40F80B87EDB90865997FFEE6DF315AB166D713AF433A5'
+        passwd = utf8('TestingInvalidFlags')
+        flags = 0x10 # BIP38_FLAG_RESERVED1
+
+        ret, bip38 = self.from_priv(priv_key, passwd, flags)
+        self.assertEqual(ret, WALLY_EINVAL)
+
+        ret, bip38 = self.from_priv(priv_key, passwd, flags + K_RAW)
+        self.assertEqual(ret, WALLY_EINVAL)
+        
+        ret, bip38 = self.from_priv(priv_key, passwd, K_MAIN)
+        self.assertEqual(ret, WALLY_OK)
+
+        bip38 = bip38.decode('utf-8') if type(bip38) is bytes else bip38
+        ret, new_priv_key = self.to_priv(bip38, passwd, flags)
+        self.assertEqual(ret, WALLY_EINVAL)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Analogous to #7 but with bip38.

Test for flag bits that are not yet defined to prevent back compat issues with existing users going forward.
