### PR TITLE
Introduce wally_format_bitcoin_message()

### DIFF
--- a/include/wally_crypto.h
+++ b/include/wally_crypto.h
@@ -412,4 +412,27 @@ WALLY_CORE_API int wally_ec_sig_verify(
     const unsigned char *sig_in,
     size_t sig_in_len);
 
+/** Flags for bitcoin message formatting */
+#define BITCOIN_MESSAGE_SERIALIZED_FLAG 0
+#define BITCOIN_MESSAGE_HASH_FLAG       1
+
+/**
+ * Append bitcoin core's preffix for signing arbitrary messages.
+ *
+ * @bytes_in: The message string to sign.
+ * @len_in: The length of @bytes_in in bytes. Can't be 0.
+ * @flags: For future extensions like returning just the hash of the message.
+ *        If BITCOIN_MESSAGE_SERIALIZED_FLAG is passed, the formatted message is put in @bytes_out.
+ *        If BITCOIN_MESSAGE_HASH_FLAG is passed, the hash is put @bytes_out.
+ * @bytes_out: Destination of the message string to sign, with the preffix added.
+ * @len: The length of @bytes_out in bytes.
+ * @written: Destination for the number of bytes written to @bytes_out.
+ */
+WALLY_CORE_API int wally_format_bitcoin_message(const unsigned char *bytes_in,
+                                                size_t len_in,
+                                                uint32_t flags,
+                                                unsigned char *bytes_out,
+                                                size_t len,
+                                                size_t *written);
+
 #endif /* LIBWALLY_CORE_CRYPTO_H */

--- a/src/swig_java/swig.i
+++ b/src/swig_java/swig.i
@@ -302,6 +302,7 @@ typedef unsigned int uint32_t;
 %returns_void__(wally_ec_sig_verify);
 %returns_string(wally_hex_from_bytes);
 %returns_size_t(wally_hex_to_bytes);
+%returns_size_t(wally_format_bitcoin_message);
 %returns_void__(wally_scrypt);
 %returns_array_(wally_sha256, 3, 4, SHA256_LEN);
 %returns_array_(wally_sha256d, 3, 4, SHA256_LEN);

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -101,6 +101,7 @@ for f in (
     ('wally_ec_sig_verify', c_int, [c_void_p, c_ulong, c_void_p, c_ulong, c_uint, c_void_p, c_ulong]),
     ('wally_get_operations', c_int, [POINTER(operations)]),
     ('wally_set_operations', c_int, [POINTER(operations)]),
+    ('wally_format_bitcoin_message', c_int, [c_void_p, c_ulong, c_uint, c_void_p, c_ulong, c_ulong_p]),
     ):
 
     def bind_fn(name, res, args):


### PR DESCRIPTION
Introduce wally_format_bitcoin_message that formats arbitrary messages to be signal like Bitcoin Core does, by adding the preffix "Bitcoin Signed Message:\n".

@jgriffiths you mentioned a flags argument too, and I could rapidly add it, but since wally_ec_sig_to_der() isn't taking one, I really don't understand why this function deserves it more.
