### PR TITLE
gitian descriptors for Linux (x86_64, ARM, and AArch64) and Android (ARM)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,7 @@ AX_PTHREAD([ac_have_pthread=yes], [ac_have_pthread=no])
 AM_CONDITIONAL([USE_PTHREAD], [test "x$ac_have_pthread" == "xyes"])
 if test "x$ac_have_pthread" == "xyes"; then
     AC_DEFINE([HAVE_PTHREAD], 1, [Define if we have pthread support])
+    AC_CHECK_HEADERS([asm/page.h])
 fi
 
 #

--- a/contrib/gitian-descriptors/libwally-core-android.yml
+++ b/contrib/gitian-descriptors/libwally-core-android.yml
@@ -1,0 +1,59 @@
+---
+name: "libwally-core-linux"
+enable_cache: false
+suites:
+- "trusty"
+architectures:
+- "amd64"
+packages:
+- "gcc-arm-linux-androideabi"
+- "git-core"
+- "pkg-config"
+- "autoconf"
+- "libtool"
+- "automake"
+- "faketime"
+- "bsdmainutils"
+- "ca-certificates"
+- "python"
+remotes:
+- "dir": "libwally-core"
+  "url": "https://github.com/jgriffiths/libwally-core.git"
+files: []
+script: |
+
+  HOSTS="arm-linux-androideabi"
+  CONFIGFLAGS="CFLAGS=-D__STDC_INT64__"
+  DISTNAME='libwally-core'
+
+  export GZIP="-9n"
+  export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export TZ="UTC"
+  export BUILD_DIR=`pwd`
+
+  SOURCEDIST="$HOME/libwallet-core.tar"
+
+  cd "${DISTNAME}"
+  tools/autogen.sh
+  tar -cvpf "${SOURCEDIST}" . --exclude=.git
+
+  ORIGPATH="$PATH"
+  # Extract the release tarball into a dir for each host and build
+  for i in ${HOSTS}; do
+    export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
+    mkdir -p distsrc-${i}
+    cd distsrc-${i}
+    INSTALLPATH=`pwd`/installed/${DISTNAME}
+    mkdir -p ${INSTALLPATH}
+    tar -xf $SOURCEDIST
+
+    ./configure --host="$i" --prefix=/ --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
+    make ${MAKEOPTS}
+
+    make install DESTDIR=${INSTALLPATH}
+    cd installed
+    "${i}-strip" --strip-unneeded "${DISTNAME}"/lib/libwallycore.so
+    ls "${DISTNAME}"/lib/libwallycore* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    cd ../../
+    rm -rf distsrc-${i}
+  done

--- a/contrib/gitian-descriptors/libwally-core-linux.yml
+++ b/contrib/gitian-descriptors/libwally-core-linux.yml
@@ -1,0 +1,69 @@
+---
+name: "libwally-core-linux"
+enable_cache: false
+suites:
+- "trusty"
+architectures:
+- "amd64"
+packages:
+- "g++-aarch64-linux-gnu"
+- "g++-4.8-aarch64-linux-gnu"
+- "gcc-4.8-aarch64-linux-gnu"
+- "binutils-aarch64-linux-gnu"
+- "g++-arm-linux-gnueabihf"
+- "g++-4.8-arm-linux-gnueabihf"
+- "gcc-4.8-arm-linux-gnueabihf"
+- "binutils-arm-linux-gnueabihf"
+- "g++-4.8-multilib"
+- "gcc-4.8-multilib"
+- "binutils-gold"
+- "git-core"
+- "pkg-config"
+- "autoconf"
+- "libtool"
+- "automake"
+- "faketime"
+- "bsdmainutils"
+- "ca-certificates"
+- "python"
+remotes:
+- "dir": "libwally-core"
+  "url": "https://github.com/jgriffiths/libwally-core.git"
+files: []
+script: |
+
+  HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
+  CONFIGFLAGS=""
+  DISTNAME='libwally-core'
+
+  export GZIP="-9n"
+  export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export TZ="UTC"
+  export BUILD_DIR=`pwd`
+
+  SOURCEDIST="$HOME/libwallet-core.tar"
+
+  cd "${DISTNAME}"
+  tools/autogen.sh
+  tar -cvpf "${SOURCEDIST}" . --exclude=.git
+
+  ORIGPATH="$PATH"
+  # Extract the release tarball into a dir for each host and build
+  for i in ${HOSTS}; do
+    export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
+    mkdir -p distsrc-${i}
+    cd distsrc-${i}
+    INSTALLPATH=`pwd`/installed/${DISTNAME}
+    mkdir -p ${INSTALLPATH}
+    tar -xf $SOURCEDIST
+
+    ./configure --host="$i" --prefix=/ --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
+    make ${MAKEOPTS}
+
+    make install DESTDIR=${INSTALLPATH}
+    cd installed
+    "${i}-strip" --strip-unneeded "${DISTNAME}"/lib/libwallycore.so
+    ls "${DISTNAME}"/lib/libwallycore* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    cd ../../
+    rm -rf distsrc-${i}
+  done

--- a/src/ctest/test_clear.c
+++ b/src/ctest/test_clear.c
@@ -1,3 +1,8 @@
+#include "config.h"
+
+#ifdef HAVE_ASM_PAGE_H
+#   include <asm/page.h>
+#endif
 #include <wally_bip32.h>
 #include <wally_bip39.h>
 #include <pthread.h>


### PR DESCRIPTION
My output, for comparison:

```
39488178b003cda2fc58673c53844ca14bccb212277b7f271c7035c8dab26f49  libwally-core-arm-linux-androideabi.tar.gz

c49ad64b52b5ac3e0317814a815297f3ca31609cd2831b14c02827aee5c011bb  libwally-core-aarch64-linux-gnu.tar.gz
dc8b494bbe823302388484d2b763e1bfbd72ab7dd56462813e71e7aab5d940c9  libwally-core-arm-linux-gnueabihf.tar.gz
e27eb27c60e629fd21bff3b43d311e5930f4702e99c16e9cde3ddf795e97f82b  libwally-core-x86_64-linux-gnu.tar.gz
```